### PR TITLE
JPA Auditing 적용

### DIFF
--- a/src/main/java/com/api/trip/common/auditing/config/AuditingConfig.java
+++ b/src/main/java/com/api/trip/common/auditing/config/AuditingConfig.java
@@ -1,0 +1,21 @@
+package com.api.trip.common.auditing.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import java.util.Optional;
+
+@Configuration
+@EnableJpaAuditing
+public class AuditingConfig {
+
+    // TODO: 회원가입 후 유저 정보를 가져와서 넣어주는 방법을 모르겠습니다...
+    /**
+    @Bean
+    public AuditorAware<String> auditorAware() {
+        return () -> Optional.of("user1");
+    }
+    */
+}

--- a/src/main/java/com/api/trip/common/auditing/entity/BaseTimeEntity.java
+++ b/src/main/java/com/api/trip/common/auditing/entity/BaseTimeEntity.java
@@ -1,0 +1,26 @@
+package com.api.trip.common.auditing.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime modifiedAt;
+
+}

--- a/src/main/java/com/api/trip/domain/email/model/EmailAuth.java
+++ b/src/main/java/com/api/trip/domain/email/model/EmailAuth.java
@@ -1,5 +1,6 @@
 package com.api.trip.domain.email.model;
 
+import com.api.trip.common.auditing.entity.BaseTimeEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -14,7 +15,7 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class EmailAuth {
+public class EmailAuth extends BaseTimeEntity {
 
     private static final Long MAX_EXPIRE_TIME = 5L; // 링크 유효 기간 5분
 

--- a/src/main/java/com/api/trip/domain/member/model/Member.java
+++ b/src/main/java/com/api/trip/domain/member/model/Member.java
@@ -1,5 +1,6 @@
 package com.api.trip.domain.member.model;
 
+import com.api.trip.common.auditing.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -9,7 +10,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Member {
+public class Member extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
데이터의 `생성일, 수정일`을 자동으로 관리하기 위해 auditing 클래스를 추가하고 엔티티에 적용함.

- 회원 가입 시점에 SecurityContext에 회원 정보가 존재하지 않아서 생성자, 수정자 값이 `Anonymous`로 출력됨.. 생성자, 수정자는 auditing 필드에서 일단 제외시킴.


This closed #24 