### PR TITLE
회원 탈퇴 기능 구현

### DIFF
--- a/src/main/java/com/api/trip/common/auditing/entity/BaseTimeEntity.java
+++ b/src/main/java/com/api/trip/common/auditing/entity/BaseTimeEntity.java
@@ -23,4 +23,6 @@ public class BaseTimeEntity {
     @Column(nullable = false)
     private LocalDateTime modifiedAt;
 
+    private LocalDateTime deletedAt;
+
 }

--- a/src/main/java/com/api/trip/domain/member/controller/MemberController.java
+++ b/src/main/java/com/api/trip/domain/member/controller/MemberController.java
@@ -47,4 +47,14 @@ public class MemberController {
         emailService.sendNewPassword(findPasswordRequest.getEmail());
         return ResponseEntity.ok().build();
     }
+
+    @PreAuthorize("isAuthenticated()")
+    @DeleteMapping("/me")
+    public ResponseEntity<Void> deleteMember(@RequestBody DeleteRequest deleteRequest) {
+        String email = SecurityUtils.getCurrentUsername();
+        memberService.deleteMember(email, deleteRequest.getPassword());
+
+        return ResponseEntity.ok().build();
+    }
+
 }

--- a/src/main/java/com/api/trip/domain/member/controller/dto/DeleteRequest.java
+++ b/src/main/java/com/api/trip/domain/member/controller/dto/DeleteRequest.java
@@ -1,0 +1,14 @@
+package com.api.trip.domain.member.controller.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DeleteRequest {
+
+    private String password;
+
+}

--- a/src/main/java/com/api/trip/domain/member/model/Member.java
+++ b/src/main/java/com/api/trip/domain/member/model/Member.java
@@ -6,10 +6,14 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE member SET deleted_at = NOW() WHERE id = ?")
+@SQLRestriction("deleted_at IS NULL")
 public class Member extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/com/api/trip/domain/member/service/MemberService.java
+++ b/src/main/java/com/api/trip/domain/member/service/MemberService.java
@@ -19,6 +19,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.security.SecureRandom;
+import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
@@ -57,6 +58,16 @@ public class MemberService {
 
         JwtToken jwtToken = jwtTokenProvider.createJwtToken(loginRequest.getEmail(), authorities);
         return LoginResponse.of(jwtToken);
+    }
+
+    public void deleteMember(String email, String password) {
+        Member member = getMemberByEmail(email);
+
+        if (!passwordEncoder.matches(password, member.getPassword())) {
+            throw new RuntimeException("비밀번호가 일치하지 않습니다.");
+        }
+
+        memberRepository.deleteById(member.getId());
     }
 
     // 회원의 비밀번호를 메일로 전송한 임시 비밀번호로 변경

--- a/src/test/java/com/api/trip/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/api/trip/domain/member/controller/MemberControllerTest.java
@@ -1,0 +1,77 @@
+package com.api.trip.domain.member.controller;
+
+import com.api.trip.domain.member.controller.dto.DeleteRequest;
+import com.api.trip.domain.member.service.MemberService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class MemberControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private MemberService memberService;
+
+    @DisplayName("[API] - 회원 삭제 성공")
+    @WithMockUser
+    @Test
+    void successDeleteMember() throws Exception {
+
+        String email = "test@email.com";
+        String password = "1234";
+
+        doNothing().when(memberService).deleteMember(email, password);
+
+        mvc.perform(delete("/api/members/me")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(new DeleteRequest(password)))
+                )
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    /**
+     * 에러 처리가 안되있어서 응답 실패시에도 200 응답이 떨어지기 때문에 실패 테스트는 현재 진행 불가능
+    @DisplayName("[API] - 회원 삭제 실패 - 현재 비밀번호를 잘못 입력한 경우")
+    @WithMockUser
+    @Test
+    void deleteDeleteMember() throws Exception {
+
+        String email = "test@email.com";
+        String password = "1234";
+        String wrongPassword = "1111";
+
+        doThrow(new RuntimeException("비밀번호가 일치하지 않습니다.")).when(memberService).deleteMember(email, wrongPassword);
+
+        mvc.perform(delete("/api/members/me")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(new DeleteRequest(wrongPassword)))
+                )
+                .andExpect(status().isConflict())
+                .andDo(print());
+    }
+    */
+
+
+}

--- a/src/test/java/com/api/trip/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/api/trip/domain/member/service/MemberServiceTest.java
@@ -1,0 +1,58 @@
+package com.api.trip.domain.member.service;
+
+import com.api.trip.domain.member.model.Member;
+import com.api.trip.domain.member.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.*;
+
+@DisplayName("비즈니스 로직 - 회원")
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+
+    @InjectMocks
+    private MemberService memberService;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Spy
+    private PasswordEncoder passwordEncoder;
+
+    @DisplayName("현재 비밀번호를 입력하면 회원 탈퇴가 완료된다.")
+    @Test
+    void successDeleteMember() {
+
+        // Given
+        String email = "test@email.com";
+        String password = "1234";
+
+        Member member = Member.builder()
+                .password(passwordEncoder.encode(password))
+                .build();
+
+        when(memberRepository.findByEmail(anyString())).thenReturn(Optional.of(mock(Member.class)));
+        when(passwordEncoder.matches(password, member.getPassword())).thenReturn(true);
+        doNothing().when(memberRepository).deleteById(anyLong());
+
+        // When
+        memberService.deleteMember(email, password);
+
+        // Then
+        then(memberRepository).should().findByEmail(anyString());
+        then(passwordEncoder).should().matches(password, member.getPassword());
+        then(memberRepository).should().deleteById(anyLong());
+    }
+
+}


### PR DESCRIPTION
- `soft delete` 방식으로 회원 탈퇴 기능을 구현함.
- 삭제시 `삭제일(deleted_at)`을 현재 날짜로 갱신해주고, 조회시 삭제일이 null인 회원들만 조회하도록 설정함.
- `@Where`이 deprecated 되어서 `@SQLRestriction` 사용

참고 링크
- https://docs.jboss.org/hibernate/stable/orm/javadocs/org/hibernate/annotations/Where.html

This closed #32 

