### PR TITLE
프로필 이미지 업로드 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,37 +26,37 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
-
-	// mail
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 
-	//Querydsl 추가
+	// aws
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+	implementation 'com.amazonaws:aws-java-sdk-s3:1.12.429'
+	implementation 'javax.xml.bind:jaxb-api:2.4.0-b180830.0359'
+
+	// tika
+	implementation 'org.apache.tika:tika-core:2.9.1'
+
+	// Swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+
 	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
 	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
-
-
-	// mysql
-	runtimeOnly 'com.mysql:mysql-connector-j'
-
-	// h2
-	runtimeOnly 'com.h2database:h2'
-
-	// lombok
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.projectlombok:lombok'
 
 	// Jwt
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
 
-    // Swagger
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+	runtimeOnly 'com.mysql:mysql-connector-j'
+	runtimeOnly 'com.h2database:h2'
+
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
+	testImplementation 'org.projectlombok:lombok'
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.security:spring-security-test'
 
 }
 

--- a/src/main/java/com/api/trip/domain/aws/config/AmazonS3Config.java
+++ b/src/main/java/com/api/trip/domain/aws/config/AmazonS3Config.java
@@ -1,0 +1,33 @@
+package com.api.trip.domain.aws.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AmazonS3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3Client() {
+        BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return AmazonS3ClientBuilder
+                .standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+}

--- a/src/main/java/com/api/trip/domain/aws/service/AmazonS3Service.java
+++ b/src/main/java/com/api/trip/domain/aws/service/AmazonS3Service.java
@@ -1,0 +1,65 @@
+package com.api.trip.domain.aws.service;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class AmazonS3Service {
+
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Getter
+    @Value("${cloud.aws.default-image}")
+    private String defaultProfileImg;
+
+    public String upload(MultipartFile profileImg) {
+
+        // 파일 확장자 분리 (.png, .jpg, .gif)
+        String ext = Optional.ofNullable(profileImg.getOriginalFilename())
+                .filter(f -> f.contains("."))
+                .map(f -> f.split("\\.")[1])
+                .orElse("");
+
+        // 파일 이름은 UUID.ext 형식으로 업로드
+        String fileName = "%s.%s".formatted(UUID.randomUUID(), ext);
+        String formatDate = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy_MM_dd"));
+        String s3location = bucket + "/members/" + formatDate;
+
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(profileImg.getSize());
+        metadata.setContentType(profileImg.getContentType());
+
+        try {
+            log.debug("uploading aws s3.. upload path: {}", s3location + fileName);
+            amazonS3.putObject(s3location, fileName, profileImg.getInputStream(), metadata);
+        } catch (IOException e) {
+            // TODO: add exception
+            throw new RuntimeException("Fail AWS S3 Upload.. {}", e);
+        }
+
+        return String.valueOf(amazonS3.getUrl(s3location, fileName));
+    }
+
+    // TODO: 회원 정보 수정 구현시 필요
+    public void delete(String key) {
+        amazonS3.deleteObject(bucket, key);
+    }
+
+}

--- a/src/main/java/com/api/trip/domain/aws/util/MultipartFileUtils.java
+++ b/src/main/java/com/api/trip/domain/aws/util/MultipartFileUtils.java
@@ -1,0 +1,18 @@
+package com.api.trip.domain.aws.util;
+
+import org.apache.tika.Tika;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+
+public class MultipartFileUtils {
+
+    final static String[] PERMISSION_PROFILE_FILE_MIME_TYPE = {"image/jpeg", "image/png", "image/gif"};
+
+    // 파일 변조 여부 검사
+    public static boolean isPermission(InputStream inputStream) throws IOException {
+        String mimeType = new Tika().detect(inputStream);
+        return Arrays.stream(PERMISSION_PROFILE_FILE_MIME_TYPE).anyMatch(type -> type.equalsIgnoreCase(mimeType));
+    }
+}

--- a/src/main/java/com/api/trip/domain/member/controller/MemberController.java
+++ b/src/main/java/com/api/trip/domain/member/controller/MemberController.java
@@ -1,12 +1,24 @@
 package com.api.trip.domain.member.controller;
 
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.api.trip.domain.email.service.EmailService;
 import com.api.trip.domain.member.controller.dto.*;
 import com.api.trip.domain.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Optional;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/members")
@@ -16,9 +28,10 @@ public class MemberController {
     private final MemberService memberService;
     private final EmailService emailService;
 
-    @PostMapping("/join")
-    public ResponseEntity<Void> join(@RequestBody JoinRequest joinRequest) {
-        memberService.join(joinRequest);
+    @PostMapping(value = "/join", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
+    public ResponseEntity<Void> join(@RequestPart JoinRequest joinRequest, @RequestPart(required = false) MultipartFile profileImg) throws IOException {
+
+        memberService.join(joinRequest, profileImg);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/api/trip/domain/member/model/Member.java
+++ b/src/main/java/com/api/trip/domain/member/model/Member.java
@@ -1,6 +1,7 @@
 package com.api.trip.domain.member.model;
 
 import com.api.trip.common.auditing.entity.BaseTimeEntity;
+import com.api.trip.domain.member.controller.dto.JoinRequest;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -29,6 +30,9 @@ public class Member extends BaseTimeEntity {
     @Column(nullable = false)
     private String password;
 
+    @Column(nullable = false) // 기본 이미지가 무조건 들어갈 예정.
+    private String profileImg;
+
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private MemberRole role;
@@ -36,11 +40,21 @@ public class Member extends BaseTimeEntity {
     private boolean emailAuth;
 
     @Builder
-    private Member(String email, String nickname, String password){
+    private Member(String email, String password, String nickname, String profileImg){
         this.email = email;
-        this.nickname = nickname;
         this.password = password;
+        this.nickname = nickname;
+        this.profileImg = profileImg;
         this.role = MemberRole.MEMBER;
+    }
+
+    public static Member of(String email, String password, String nickname, String profileImg) {
+        return Member.builder()
+                .email(email)
+                .password(password)
+                .nickname(nickname)
+                .profileImg(profileImg)
+                .build();
     }
 
     // 이메일 인증 상태 변경 메서드

--- a/src/main/java/com/api/trip/domain/member/service/MemberService.java
+++ b/src/main/java/com/api/trip/domain/member/service/MemberService.java
@@ -3,6 +3,8 @@ package com.api.trip.domain.member.service;
 import com.api.trip.common.security.jwt.JwtToken;
 import com.api.trip.common.security.jwt.JwtTokenProvider;
 import com.api.trip.common.security.util.SecurityUtils;
+import com.api.trip.domain.aws.util.MultipartFileUtils;
+import com.api.trip.domain.aws.service.AmazonS3Service;
 import com.api.trip.domain.email.model.EmailAuth;
 import com.api.trip.domain.email.repository.EmailAuthRepository;
 import com.api.trip.domain.member.controller.dto.DeleteRequest;
@@ -19,7 +21,9 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.stream.Collectors;
 
 @Service
@@ -30,21 +34,45 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final EmailAuthRepository emailAuthRepository;
     private final PasswordEncoder passwordEncoder;
+    private final AmazonS3Service amazonS3Service;
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
     private final JwtTokenProvider jwtTokenProvider;
 
-    public void join(JoinRequest joinRequest) {
-        // 중복 회원 체크
+    public void join(JoinRequest joinRequest, MultipartFile profileImg) throws IOException {
+
+        // 중복된 회원이 있는지 검사
         memberRepository.findByEmail(joinRequest.getEmail()).ifPresent(it -> {
             throw new RuntimeException("이미 존재하는 회원 입니다.");
         });
 
+        // 이메일 인증이 완료 여부 검사
         EmailAuth emailAuth = emailAuthRepository.findByEmail(joinRequest.getEmail())
-                .orElseThrow(() -> new RuntimeException("토큰 정보가 없습니다!"));
+                .orElseThrow(() -> new RuntimeException("이메일 인증 토큰 정보가 없습니다!"));
 
-        Member member = JoinRequest.of(joinRequest, passwordEncoder.encode(joinRequest.getPassword()));
+        String profileImgUrl = "";
+        if (profileImg == null || profileImg.isEmpty()) {
+            // 프로필 사진 데이터가 없으면 기본 이미지 세팅
+            profileImgUrl = amazonS3Service.getDefaultProfileImg();
+        } else {
+            // 파일 변조 여부 체크
+            if (!MultipartFileUtils.isPermission(profileImg.getInputStream())) {
+                throw new RuntimeException("프로필 사진은 이미지 파일만 선택 가능합니다!");
+            }
+
+            // 요청 파일 이미지가 있는 경우 s3 업로드
+            profileImgUrl = amazonS3Service.upload(profileImg);
+        }
+
+        Member member = Member.of(
+                joinRequest.getEmail(),
+                passwordEncoder.encode(joinRequest.getPassword()),
+                joinRequest.getNickname(),
+                profileImgUrl
+        );
+
         member.emailVerifiedSuccess();
 
+        // TODO: 회원 가입이 실패하는 경우 s3에 있는 파일 삭제 처리 고민 해보기
         memberRepository.save(member);
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,6 +13,10 @@ spring:
     web:
       pageable:
         one-indexed-parameters: true
+  servlet:
+    multipart:
+      max-file-size: 20MB
+      max-request-size: 50MB
 
 logging:
   level:


### PR DESCRIPTION
`aws s3`를 사용해서 프로필 이미지 업로드 기능을 구현함.

- 프로필 이미지는 `jpeg, png, gif` 파일만 사용이 가능하도록 구현
  - `tika` 라이브러리를 사용해서 파일 변조 여부를 검사
- 회원 프로필은 회원당 1개만 존재하기 때문에 컬럼으로 관리하는 방식으로 구현
- 파일은 `members/현재 날짜/파일 이름` 형식으로 관리 `ex) members/2023_12_13/fileName.png`

This closed #39 