### PR TITLE
OAuthSuccessHandler 버그 수정

### DIFF
--- a/src/main/java/com/api/trip/common/security/oauth/OAuth2Attribute.java
+++ b/src/main/java/com/api/trip/common/security/oauth/OAuth2Attribute.java
@@ -21,18 +21,19 @@ public class OAuth2Attribute {
     private String email; // 이메일
     private String name; // 이름
     private String picture; // 프로필 사진
+    private String provider; // 플랫폼
 
     static OAuth2Attribute of(String provider, String attributeKey, Map<String, Object> attributes) {
         // 각 플랫폼 별로 제공해주는 데이터가 조금씩 다르기 때문에 분기 처리함.
         return switch (provider) {
-            case "google" -> google(attributeKey, attributes);
-            case "kakao" -> kakao(attributeKey, attributes);
-            case "naver" -> naver(attributeKey, attributes);
+            case "google" -> google(provider, attributeKey, attributes);
+            case "kakao" -> kakao(provider, attributeKey, attributes);
+            case "naver" -> naver(provider, attributeKey, attributes);
             default -> throw new NotFoundException(ErrorCode.NOT_FOUND_PROVIDER);
         };
     }
 
-    private static OAuth2Attribute google(String attributeKey, Map<String, Object> attributes) {
+    private static OAuth2Attribute google(String provider, String attributeKey, Map<String, Object> attributes) {
         log.debug("google: {}", attributes);
         return OAuth2Attribute.builder()
                 .email((String) attributes.get("email"))
@@ -40,23 +41,25 @@ public class OAuth2Attribute {
                 .picture((String)attributes.get("picture"))
                 .attributes(attributes)
                 .attributeKey(attributeKey)
+                .provider(provider)
                 .build();
     }
 
-    private static OAuth2Attribute kakao(String attributeKey, Map<String, Object> attributes) {
+    private static OAuth2Attribute kakao(String provider, String attributeKey, Map<String, Object> attributes) {
         Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
         Map<String, Object> kakaoProfile = (Map<String, Object>) kakaoAccount.get("profile");
 
         return OAuth2Attribute.builder()
-                .email("KAKAO_" + (String) kakaoAccount.get("email"))
+                .email((String) kakaoAccount.get("email"))
                 .name((String) kakaoProfile.get("nickname"))
                 .picture((String) kakaoProfile.get("profile_image_url"))
                 .attributes(kakaoAccount)
                 .attributeKey(attributeKey)
+                .provider(provider)
                 .build();
     }
 
-    private static OAuth2Attribute naver(String attributeKey, Map<String, Object> attributes) {
+    private static OAuth2Attribute naver(String provider, String attributeKey, Map<String, Object> attributes) {
         Map<String, Object> response = (Map<String, Object>) attributes.get("response");
 
         return OAuth2Attribute.builder()
@@ -65,6 +68,7 @@ public class OAuth2Attribute {
                 .picture((String) response.get("profile_image"))
                 .attributes(response)
                 .attributeKey(attributeKey)
+                .provider(provider)
                 .build();
     }
 
@@ -77,6 +81,7 @@ public class OAuth2Attribute {
         map.put("email", email);
         map.put("name", name);
         map.put("picture", picture);
+        map.put("provider", provider);
 
         return map;
     }

--- a/src/main/java/com/api/trip/common/security/oauth/OAuthSuccessHandler.java
+++ b/src/main/java/com/api/trip/common/security/oauth/OAuthSuccessHandler.java
@@ -41,13 +41,17 @@ public class OAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
         OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
 
-        String email = oAuth2User.getAttribute("email");
+        String provider = oAuth2User.getAttribute("provider");
+
+        // KAKAO_user123@naver.com
+        String email = provider + "_" + oAuth2User.getAttribute("email");
         Optional<Member> findMember = memberRepository.findByEmail(email);
 
         // 회원이 아닌 경우에 회원 가입 진행
         Member member = null;
         if (findMember.isEmpty()) {
-            String name = oAuth2User.getAttribute("name");
+            // KAKAO_user123
+            String name = provider + "_" + oAuth2User.getAttribute("name");
             String picture = oAuth2User.getAttribute("picture");
 
             member = Member.of(email, "", name, picture);

--- a/src/main/java/com/api/trip/common/security/oauth/OAuthSuccessHandler.java
+++ b/src/main/java/com/api/trip/common/security/oauth/OAuthSuccessHandler.java
@@ -1,5 +1,7 @@
 package com.api.trip.common.security.oauth;
 
+import com.api.trip.common.exception.ErrorCode;
+import com.api.trip.common.exception.custom_exception.NotFoundException;
 import com.api.trip.common.security.jwt.JwtToken;
 import com.api.trip.common.security.jwt.JwtTokenProvider;
 import com.api.trip.domain.member.controller.dto.LoginResponse;
@@ -43,29 +45,25 @@ public class OAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
         Optional<Member> findMember = memberRepository.findByEmail(email);
 
         // 회원이 아닌 경우에 회원 가입 진행
-
-        Long memberId = 0L;
-        String role = "";
-
+        Member member = null;
         if (findMember.isEmpty()) {
             String name = oAuth2User.getAttribute("name");
             String picture = oAuth2User.getAttribute("picture");
 
-            Member member = Member.of(email, "", name, picture);
+            member = Member.of(email, "", name, picture);
             memberRepository.save(member);
-
-            memberId = member.getId();
-            role = member.getRole().getValue();
+        } else {
+            member = findMember.orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_MEMBER));
         }
 
         // OAuth2User 객체에서 권한 가져옴
-        JwtToken jwtToken = jwtTokenProvider.createJwtToken(email, role);
+        JwtToken jwtToken = jwtTokenProvider.createJwtToken(member.getEmail(), member.getRole().getValue());
 
-        // 쿠키 세팅
-        response.addHeader(HttpHeaders.SET_COOKIE, createCookie("tokenType", "Bearer"));
         response.addHeader(HttpHeaders.SET_COOKIE, createCookie("accessToken", jwtToken.getAccessToken()));
         response.addHeader(HttpHeaders.SET_COOKIE, createCookie("refreshToken", jwtToken.getRefreshToken()));
-        response.addHeader(HttpHeaders.SET_COOKIE, createCookie("memberId", String.valueOf(memberId)));
+        response.addHeader(HttpHeaders.SET_COOKIE, createCookie("memberId", String.valueOf(member.getId())));
+
+        // TODO: 프론트 배포 주소로 변경 예정
         response.sendRedirect("http://localhost:5173/home");
     }
 
@@ -73,7 +71,9 @@ public class OAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
         return ResponseCookie.from(name, value)
                 .path("/")
                 .httpOnly(true)
-                .sameSite("None")
+                .maxAge(60 * 60 * 6)
+                // .sameSite("None") https 시 활성화
+                //.secure(true) https 시 활성화
                 .build()
                 .toString();
     }


### PR DESCRIPTION
- OAuthSuccessHandler에서 유저 정보를 제대로 담지 못하는 버그를 발견해서 수정함.
- 소셜 로그인 유저의 정보를 db에 저장할 때 이메일, 닉네임에 플랫폼 이름을 붙여서 일반 가입 회원과 구분 할 수 있게 수정함.
- jwt 토큰을 담은 쿠키가 현재 프론트와 백엔드의 도메인이 다르기 때문에 안넘어감.
  - 배포 후 도메인을 맞추던지, https 통신 시 쿠키 설정을 해서 해결해볼 예정


This closed #112 