### PR TITLE
Notification 테이블이 생성되지 않는 문제 해결

### DIFF
--- a/src/main/java/com/api/trip/domain/notification/domain/Notification.java
+++ b/src/main/java/com/api/trip/domain/notification/domain/Notification.java
@@ -25,7 +25,7 @@ public class Notification extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private Item item;
 
-    @Column(nullable = false)
+    @Column(name = "read_or_not", nullable = false)
     private boolean read;
 
     @Builder


### PR DESCRIPTION
- read 필드의 컬럼 이름을 "read_or_not"으로 지정