### PR TITLE
회원 정보 수정 기능 구현

### DIFF
--- a/src/main/java/com/api/trip/common/exception/ErrorCode.java
+++ b/src/main/java/com/api/trip/common/exception/ErrorCode.java
@@ -10,6 +10,7 @@ public enum ErrorCode {
     EMPTY_REFRESH_TOKEN("RefreshToken이 필요합니다.", HttpStatus.BAD_REQUEST),
     EMPTY_EMAIL("이메일이 필요합니다.", HttpStatus.BAD_REQUEST),
     INVALID_IMAGE_TYPE("유효하지 않은 파일 형식입니다.", HttpStatus.BAD_REQUEST),
+    AWS_FAIL_UPLOAD("AWS S3 업로드 실패!", HttpStatus.CONFLICT),
 
     // 401
     LOGOUTED_TOKEN("이미 로그아웃 처리된 토큰입니다.", HttpStatus.UNAUTHORIZED),

--- a/src/main/java/com/api/trip/common/exception/custom_exception/AwsS3Exception.java
+++ b/src/main/java/com/api/trip/common/exception/custom_exception/AwsS3Exception.java
@@ -1,0 +1,10 @@
+package com.api.trip.common.exception.custom_exception;
+
+import com.api.trip.common.exception.CustomException;
+import com.api.trip.common.exception.ErrorCode;
+
+public class AwsS3Exception extends CustomException {
+    public AwsS3Exception(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/api/trip/domain/aws/service/AmazonS3Service.java
+++ b/src/main/java/com/api/trip/domain/aws/service/AmazonS3Service.java
@@ -2,6 +2,8 @@ package com.api.trip.domain.aws.service;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.api.trip.common.exception.ErrorCode;
+import com.api.trip.common.exception.custom_exception.AwsS3Exception;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -50,8 +52,7 @@ public class AmazonS3Service {
             log.debug("uploading aws s3.. upload path: {}", s3location + fileName);
             amazonS3.putObject(s3location, fileName, profileImg.getInputStream(), metadata);
         } catch (IOException e) {
-            // TODO: add exception
-            throw new RuntimeException("Fail AWS S3 Upload.. {}", e);
+            throw new AwsS3Exception(ErrorCode.AWS_FAIL_UPLOAD);
         }
 
         return String.valueOf(amazonS3.getUrl(s3location, fileName));

--- a/src/main/java/com/api/trip/domain/member/controller/MemberController.java
+++ b/src/main/java/com/api/trip/domain/member/controller/MemberController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/members")
@@ -43,7 +44,6 @@ public class MemberController {
     }
 
     // 인증 메일 전송
-    // TODO: 리팩토링 예정..
     @PostMapping("/send-email/{email}")
     public void sendAuthEmail(@PathVariable String email) {
         emailService.send(email, emailService.createEmailAuth(email));
@@ -65,6 +65,13 @@ public class MemberController {
     @PostMapping("/find/password")
     public ResponseEntity<Void> sendNewPassword(@RequestBody FindPasswordRequest findPasswordRequest) {
         emailService.sendNewPassword(findPasswordRequest);
+        return ResponseEntity.ok().build();
+    }
+
+    @PreAuthorize("isAuthenticated()")
+    @PatchMapping("/me")
+    public ResponseEntity<Void> updateProfile(@ModelAttribute UpdateProfileRequest updateProfileRequest) throws IOException {
+        memberService.updateProfile(updateProfileRequest);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/api/trip/domain/member/controller/dto/UpdateProfileRequest.java
+++ b/src/main/java/com/api/trip/domain/member/controller/dto/UpdateProfileRequest.java
@@ -1,0 +1,17 @@
+package com.api.trip.domain.member.controller.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class UpdateProfileRequest {
+
+    private MultipartFile profileImg;
+    private String nickname;
+    private String intro;
+    private List<String> tags;
+}

--- a/src/main/java/com/api/trip/domain/member/model/Member.java
+++ b/src/main/java/com/api/trip/domain/member/model/Member.java
@@ -2,6 +2,7 @@ package com.api.trip.domain.member.model;
 
 import com.api.trip.common.auditing.entity.BaseTimeEntity;
 import com.api.trip.domain.member.controller.dto.JoinRequest;
+import com.api.trip.domain.member.controller.dto.UpdateProfileRequest;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -30,7 +31,9 @@ public class Member extends BaseTimeEntity {
     @Column(nullable = false)
     private String password;
 
-    @Column(nullable = false) // 기본 이미지가 무조건 들어갈 예정.
+    private String intro; // 자기 소개
+
+    @Column(nullable = false)
     private String profileImg;
 
     @Column(nullable = false)
@@ -64,5 +67,14 @@ public class Member extends BaseTimeEntity {
 
     public void changePassword(String password) {
         this.password = password;
+    }
+
+    public void changeProfileImg(String profileImgUrl) {
+        this.profileImg = profileImgUrl;
+    }
+
+    public void changeProfile(UpdateProfileRequest updateProfileRequest) {
+        this.nickname = updateProfileRequest.getNickname();
+        this.intro = updateProfileRequest.getIntro();
     }
 }


### PR DESCRIPTION
- 프로필 이미지 수정 로직 2가지로 분리
  - 기본 이미지인 경우 새 이미지가 들어오면 s3에 새 이미지 업로드
  - 직접 설정한 프로필 이미지를 가진 경우 기존에 s3에 있던 이미지를 지우고 새 이미지를 s3에 업로드
- 자기소개 설정을 위해 회원 엔티티에 intro 필드 추가

## 미구현 사항
- 관심 태그는 기존 코드 리팩토링 후 진행할 예정


This closed #129 