### PR TITLE
관심 태그 설정 기능 구현

### DIFF
--- a/src/main/java/com/api/trip/domain/interesttag/model/InterestTag.java
+++ b/src/main/java/com/api/trip/domain/interesttag/model/InterestTag.java
@@ -1,0 +1,26 @@
+package com.api.trip.domain.interesttag.model;
+
+import com.api.trip.common.auditing.entity.BaseTimeEntity;
+import com.api.trip.domain.member.model.Member;
+import com.api.trip.domain.tag.model.Tag;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class InterestTag extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Tag tag;
+
+}

--- a/src/main/java/com/api/trip/domain/interesttag/respository/InterestTagRepository.java
+++ b/src/main/java/com/api/trip/domain/interesttag/respository/InterestTagRepository.java
@@ -1,0 +1,7 @@
+package com.api.trip.domain.interesttag.respository;
+
+import com.api.trip.domain.interesttag.model.InterestTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InterestTagRepository extends JpaRepository<InterestTag, Long> {
+}

--- a/src/main/java/com/api/trip/domain/interesttag/service/InterestTagService.java
+++ b/src/main/java/com/api/trip/domain/interesttag/service/InterestTagService.java
@@ -1,0 +1,47 @@
+package com.api.trip.domain.interesttag.service;
+
+import com.api.trip.domain.interesttag.model.InterestTag;
+import com.api.trip.domain.interesttag.respository.InterestTagRepository;
+import com.api.trip.domain.member.model.Member;
+import com.api.trip.domain.tag.model.Tag;
+import com.api.trip.domain.tag.repository.TagRepository;
+import com.api.trip.domain.tag.service.TagService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Slf4j
+@Transactional
+@RequiredArgsConstructor
+public class InterestTagService {
+
+    private final InterestTagRepository interestTagRepository;
+    private final TagRepository tagRepository;
+
+    // 관심 태그 저장
+    public void createTag(Member member, List<String> tagNames) {
+
+        // 태그 테이블에서 태그 검색
+        List<Tag> tags = tagRepository.findByNameIn(tagNames);
+
+        // 관심 태그 테이블에 저장
+        for (Tag tag : tags) {
+            InterestTag interestTag = InterestTag.builder()
+                    .member(member)
+                    .tag(tag)
+                    .build();
+
+            interestTagRepository.save(interestTag);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public List<String> getInterestTag() {
+        // TODO: 회원의 관심 태그 출력하는 로직 작성
+        return List.of();
+    }
+}

--- a/src/main/java/com/api/trip/domain/member/service/MemberService.java
+++ b/src/main/java/com/api/trip/domain/member/service/MemberService.java
@@ -13,6 +13,7 @@ import com.api.trip.domain.aws.util.MultipartFileUtils;
 import com.api.trip.domain.aws.service.AmazonS3Service;
 import com.api.trip.domain.email.model.EmailAuth;
 import com.api.trip.domain.email.repository.EmailAuthRepository;
+import com.api.trip.domain.interesttag.service.InterestTagService;
 import com.api.trip.domain.member.controller.dto.*;
 import com.api.trip.domain.member.model.Member;
 import com.api.trip.domain.member.model.SocialCode;
@@ -46,6 +47,7 @@ public class MemberService {
     private final EmailAuthRepository emailAuthRepository;
     private final PasswordEncoder passwordEncoder;
     private final AmazonS3Service amazonS3Service;
+    private final InterestTagService interestTagService;
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
     private final JwtTokenProvider jwtTokenProvider;
     private final JwtTokenUtils jwtTokenUtils;
@@ -153,6 +155,8 @@ public class MemberService {
             member.changeProfileImg(profileImgUrl);
         }
 
+        // 관심 태그 저장
+        interestTagService.createTag(member, updateProfileRequest.getTags());
         member.changeProfile(updateProfileRequest);
     }
 


### PR DESCRIPTION
- 관심 태그 도메인을 설계하고 회원 정보 수정 로직에 추가
- 관심 태그는 최대 5개까지 설정이 가능하도록 구현

This closed #137 