### PR TITLE
소셜 회원 탈퇴 기능 구현

### DIFF
--- a/src/main/java/com/api/trip/common/security/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/com/api/trip/common/security/oauth/CustomOAuth2UserService.java
@@ -24,8 +24,9 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 
         String registrationId = userRequest.getClientRegistration().getRegistrationId();
         String userNameAttributeName = userRequest.getClientRegistration().getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
+        String accessToken = userRequest.getAccessToken().getTokenValue();
 
-        OAuth2Attribute oAuth2Attribute = OAuth2Attribute.of(registrationId, userNameAttributeName, oAuth2User.getAttributes());
+        OAuth2Attribute oAuth2Attribute = OAuth2Attribute.of(registrationId, accessToken, userNameAttributeName, oAuth2User.getAttributes());
         Map<String, Object> memberAttribute = oAuth2Attribute.convertToMap();
 
         return new DefaultOAuth2User(Collections.singleton(new SimpleGrantedAuthority("ROLE_MEMBER")),

--- a/src/main/java/com/api/trip/common/security/oauth/OAuth2Attribute.java
+++ b/src/main/java/com/api/trip/common/security/oauth/OAuth2Attribute.java
@@ -2,6 +2,7 @@ package com.api.trip.common.security.oauth;
 
 import com.api.trip.common.exception.ErrorCode;
 import com.api.trip.common.exception.custom_exception.NotFoundException;
+import com.api.trip.domain.member.model.SocialCode;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,18 +23,20 @@ public class OAuth2Attribute {
     private String name; // 이름
     private String picture; // 프로필 사진
     private String provider; // 플랫폼
+    private SocialCode socialCode;
+    private String accessToken; // 소셜 accessToken
 
-    static OAuth2Attribute of(String provider, String attributeKey, Map<String, Object> attributes) {
+    static OAuth2Attribute of(String provider, String accessToken, String attributeKey, Map<String, Object> attributes) {
         // 각 플랫폼 별로 제공해주는 데이터가 조금씩 다르기 때문에 분기 처리함.
         return switch (provider) {
-            case "google" -> google(provider, attributeKey, attributes);
-            case "kakao" -> kakao(provider, attributeKey, attributes);
-            case "naver" -> naver(provider, attributeKey, attributes);
+            case "google" -> google(provider, accessToken, attributeKey, attributes);
+            case "kakao" -> kakao(provider, accessToken, attributeKey, attributes);
+            case "naver" -> naver(provider, accessToken, attributeKey, attributes);
             default -> throw new NotFoundException(ErrorCode.NOT_FOUND_PROVIDER);
         };
     }
 
-    private static OAuth2Attribute google(String provider, String attributeKey, Map<String, Object> attributes) {
+    private static OAuth2Attribute google(String provider, String accessToken, String attributeKey, Map<String, Object> attributes) {
         log.debug("google: {}", attributes);
         return OAuth2Attribute.builder()
                 .email((String) attributes.get("email"))
@@ -42,10 +45,12 @@ public class OAuth2Attribute {
                 .attributes(attributes)
                 .attributeKey(attributeKey)
                 .provider(provider)
+                .socialCode(SocialCode.GOOGLE)
+                .accessToken(accessToken)
                 .build();
     }
 
-    private static OAuth2Attribute kakao(String provider, String attributeKey, Map<String, Object> attributes) {
+    private static OAuth2Attribute kakao(String provider, String accessToken, String attributeKey, Map<String, Object> attributes) {
         Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
         Map<String, Object> kakaoProfile = (Map<String, Object>) kakaoAccount.get("profile");
 
@@ -56,10 +61,12 @@ public class OAuth2Attribute {
                 .attributes(kakaoAccount)
                 .attributeKey(attributeKey)
                 .provider(provider)
+                .socialCode(SocialCode.KAKAO)
+                .accessToken(accessToken)
                 .build();
     }
 
-    private static OAuth2Attribute naver(String provider, String attributeKey, Map<String, Object> attributes) {
+    private static OAuth2Attribute naver(String provider, String accessToken, String attributeKey, Map<String, Object> attributes) {
         Map<String, Object> response = (Map<String, Object>) attributes.get("response");
 
         return OAuth2Attribute.builder()
@@ -69,6 +76,8 @@ public class OAuth2Attribute {
                 .attributes(response)
                 .attributeKey(attributeKey)
                 .provider(provider)
+                .socialCode(SocialCode.NAVER)
+                .accessToken(accessToken)
                 .build();
     }
 
@@ -82,6 +91,8 @@ public class OAuth2Attribute {
         map.put("name", name);
         map.put("picture", picture);
         map.put("provider", provider);
+        map.put("accessToken", accessToken);
+        map.put("socialCode", socialCode);
 
         return map;
     }

--- a/src/main/java/com/api/trip/common/security/oauth/OAuth2Revoke.java
+++ b/src/main/java/com/api/trip/common/security/oauth/OAuth2Revoke.java
@@ -1,0 +1,97 @@
+package com.api.trip.common.security.oauth;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Slf4j
+@Component
+public class OAuth2Revoke {
+
+    @Value("${spring.security.oauth2.client.registration.naver.client-id}")
+    private String naverClientId;
+
+    @Value("${spring.security.oauth2.client.registration.naver.client-secret}")
+    private String naverClientSecret;
+
+    @Value("${custom.oauth2.kakao-revoke-uri}")
+    private String kakaoRevokeUri;
+
+    @Value("${custom.oauth2.naver-revoke-uri}")
+    private String naverRevokeUri;
+
+    @Value("${custom.oauth2.google-revoke-uri}")
+    private String googleRevokeUri;
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    public void revokeKakao(String socialAccessToken) {
+
+        log.debug("kakao revoke..");
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(HttpHeaders.AUTHORIZATION, "Bearer %s".formatted(socialAccessToken));
+
+        HttpEntity<Object> httpEntity = new HttpEntity<>(headers);
+
+        UriComponents uriBuilder = UriComponentsBuilder.fromUriString(kakaoRevokeUri)
+                .build();
+
+        restTemplate.exchange(
+                uriBuilder.toString(),
+                HttpMethod.POST,
+                httpEntity,
+                Void.class
+        );
+
+        log.debug("kakao revoke success!");
+    }
+
+    public void revokeNaver(String socialAccessToken) {
+        log.debug("naver revoke..");
+
+        UriComponents uriBuilder = UriComponentsBuilder.fromUriString(naverRevokeUri)
+                .queryParam("grant_type", "delete")
+                .queryParam("client_id", naverClientId)
+                .queryParam("client_secret", naverClientSecret)
+                .queryParam("access_token", socialAccessToken)
+                .queryParam("service_provider", "naver")
+                .build();
+
+        HttpHeaders headers = new HttpHeaders();
+        HttpEntity<Object> httpEntity = new HttpEntity<>(headers);
+
+        restTemplate.exchange(
+                uriBuilder.toString(),
+                HttpMethod.POST,
+                httpEntity,
+                Void.class
+        );
+        log.debug("revoke naver success!");
+    }
+
+    public void revokeGoogle(String socialAccessToken) {
+        log.debug("google revoke..");
+
+        UriComponents uriBuilder = UriComponentsBuilder.fromUriString(googleRevokeUri)
+                .queryParam("token", socialAccessToken)
+                .build();
+
+        HttpHeaders headers = new HttpHeaders();
+        HttpEntity<Object> httpEntity = new HttpEntity<>(headers);
+
+        restTemplate.exchange(
+                uriBuilder.toString(),
+                HttpMethod.POST,
+                httpEntity,
+                Void.class
+        );
+        log.debug("revoke google success!");
+    }
+}

--- a/src/main/java/com/api/trip/common/security/oauth/OAuthSuccessHandler.java
+++ b/src/main/java/com/api/trip/common/security/oauth/OAuthSuccessHandler.java
@@ -46,8 +46,10 @@ public class OAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
             // KAKAO_user123
             String name = provider + "_" + oAuth2User.getAttribute("name");
             String picture = oAuth2User.getAttribute("picture");
+            SocialCode socialCode = oAuth2User.getAttribute("socialCode");
+            String socialAccessToken = oAuth2User.getAttribute("accessToken");
 
-            member = Member.of(email, "", name, picture, SocialCode.SOCIAL);
+            member = Member.of(email, "", name, picture, socialCode, socialAccessToken);
             memberRepository.save(member);
         } else {
             member = findMember.orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_MEMBER));
@@ -59,18 +61,18 @@ public class OAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
         response.addHeader(HttpHeaders.SET_COOKIE, createCookie("accessToken", jwtToken.getAccessToken()));
         response.addHeader(HttpHeaders.SET_COOKIE, createCookie("refreshToken", jwtToken.getRefreshToken()));
         response.addHeader(HttpHeaders.SET_COOKIE, createCookie("memberId", String.valueOf(member.getId())));
-
-        // TODO: 프론트 배포 주소로 변경 예정
-        response.sendRedirect("http://localhost:5173/home");
+        response.addHeader(HttpHeaders.SET_COOKIE, createCookie("profileImgUrl", member.getProfileImg()));
+        
+        response.sendRedirect("https://dkoqktaeu3tic.cloudfront.net/home");
     }
 
     private static String createCookie(String name, String value) {
         return ResponseCookie.from(name, value)
                 .path("/")
                 .httpOnly(true)
+                .sameSite("None")
+                .secure(true)
                 .maxAge(60 * 60 * 6)
-                // .sameSite("None") https 시 활성화
-                //.secure(true) https 시 활성화
                 .build()
                 .toString();
     }

--- a/src/main/java/com/api/trip/domain/member/controller/MemberController.java
+++ b/src/main/java/com/api/trip/domain/member/controller/MemberController.java
@@ -101,6 +101,13 @@ public class MemberController {
     }
 
     @PreAuthorize("isAuthenticated()")
+    @DeleteMapping("/social/me")
+    public ResponseEntity<Void> deleteSocialMember() {
+        memberService.deleteSocialMember();
+        return ResponseEntity.ok().build();
+    }
+
+    @PreAuthorize("isAuthenticated()")
     @Operation(summary = "로그아웃")
     @PostMapping("/logout")
     public ResponseEntity<String> logoutMember() {

--- a/src/main/java/com/api/trip/domain/member/model/Member.java
+++ b/src/main/java/com/api/trip/domain/member/model/Member.java
@@ -40,27 +40,41 @@ public class Member extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private SocialCode socialCode;
 
+    private String socialAccessToken; // 소셜 로그인 시 발급되는 accessToken
+
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private MemberRole role;
 
     @Builder
-    private Member(String email, String password, String nickname, String profileImg, SocialCode socialCode){
+    private Member(String email, String password, String nickname, String profileImg, SocialCode socialCode, String socialAccessToken){
         this.email = email;
         this.password = password;
         this.nickname = nickname;
         this.profileImg = profileImg;
         this.socialCode = socialCode;
+        this.socialAccessToken = socialAccessToken;
         this.role = MemberRole.MEMBER;
     }
 
-    public static Member of(String email, String password, String nickname, String profileImg, SocialCode socialCode) {
+    public static Member of(String email, String password, String nickname, String profileImg) {
+        return Member.builder()
+                .email(email)
+                .password(password)
+                .nickname(nickname)
+                .profileImg(profileImg)
+                .socialCode(SocialCode.NORMAL)
+                .build();
+    }
+
+    public static Member of(String email, String password, String nickname, String profileImg, SocialCode socialCode, String socialAccessToken) {
         return Member.builder()
                 .email(email)
                 .password(password)
                 .nickname(nickname)
                 .profileImg(profileImg)
                 .socialCode(socialCode)
+                .socialAccessToken(socialAccessToken)
                 .build();
     }
 

--- a/src/main/java/com/api/trip/domain/member/model/SocialCode.java
+++ b/src/main/java/com/api/trip/domain/member/model/SocialCode.java
@@ -7,7 +7,11 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum SocialCode {
 
-    SOCIAL("SOCIAL_LOGIN"), NORMAL("NORMAL_LOGIN"),;
+    KAKAO("kakao"),
+    NAVER("naver"),
+    GOOGLE("google"),
+    NORMAL("normal"),
+    ;
 
     private final String type;
 }


### PR DESCRIPTION
소셜 회원 탈퇴 기능 구현함.

- 소셜 회원의 탈퇴는 해당 플랫폼과의 연결을 끊어야 완료된다.
- 플랫폼과의 연결을 끊고 db에서도 해당 회원의 데이터를 삭제 처리
- 연결을 끊지 않는 경우 탈퇴 후 재로그인을 하는 경우 동의 화면 표시 없이 바로 로그인이 되기 때문에 반드시 연결을 끊어줘야함.
- 현재는 컬럼으로 accessToken을 관리하는데 테이블로 관리하는 방식도 생각해보면 좋을듯..

This closed #143 