### PR TITLE
[리팩토링 ]소셜 로그인

### DIFF
--- a/src/main/java/com/api/trip/common/security/oauth/OAuthSuccessHandler.java
+++ b/src/main/java/com/api/trip/common/security/oauth/OAuthSuccessHandler.java
@@ -36,11 +36,11 @@ public class OAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
         OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
 
         String email = oAuth2User.getAttribute("email");
-        Optional<Member> findMember = memberRepository.findByEmail(email);
+        SocialCode socialCode = oAuth2User.getAttribute("socialCode");
+        Optional<Member> findMember = memberRepository.findByEmailAndSocialCode(email, socialCode);
 
         String name = oAuth2User.getAttribute("name");
         String picture = oAuth2User.getAttribute("picture");
-        SocialCode socialCode = oAuth2User.getAttribute("socialCode");
         String socialAccessToken = oAuth2User.getAttribute("accessToken");
 
         // 회원이 아닌 경우에 회원 가입 진행

--- a/src/main/java/com/api/trip/common/security/oauth/OAuthSuccessHandler.java
+++ b/src/main/java/com/api/trip/common/security/oauth/OAuthSuccessHandler.java
@@ -35,25 +35,25 @@ public class OAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
         OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
 
-        String provider = oAuth2User.getAttribute("provider");
-
-        // KAKAO_user123@naver.com
-        String email = provider + "_" + oAuth2User.getAttribute("email");
+        String email = oAuth2User.getAttribute("email");
         Optional<Member> findMember = memberRepository.findByEmail(email);
+
+        String name = oAuth2User.getAttribute("name");
+        String picture = oAuth2User.getAttribute("picture");
+        SocialCode socialCode = oAuth2User.getAttribute("socialCode");
+        String socialAccessToken = oAuth2User.getAttribute("accessToken");
 
         // 회원이 아닌 경우에 회원 가입 진행
         Member member = null;
         if (findMember.isEmpty()) {
-            // KAKAO_user123
-            String name = provider + "_" + oAuth2User.getAttribute("name");
-            String picture = oAuth2User.getAttribute("picture");
-            SocialCode socialCode = oAuth2User.getAttribute("socialCode");
-            String socialAccessToken = oAuth2User.getAttribute("accessToken");
-
             member = Member.of(email, "", name, picture, socialCode, socialAccessToken);
+
             memberRepository.save(member);
         } else {
             member = findMember.orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_MEMBER));
+            member.updateSocialMember(email, name, picture, socialAccessToken);
+
+            memberRepository.save(member);
         }
 
         // OAuth2User 객체에서 권한 가져옴

--- a/src/main/java/com/api/trip/domain/email/service/EmailService.java
+++ b/src/main/java/com/api/trip/domain/email/service/EmailService.java
@@ -10,6 +10,7 @@ import com.api.trip.domain.email.repository.EmailRedisRepository;
 import com.api.trip.domain.email.repository.EmailAuthRepository;
 import com.api.trip.domain.member.controller.dto.FindPasswordRequest;
 import com.api.trip.domain.member.model.Member;
+import com.api.trip.domain.member.model.SocialCode;
 import com.api.trip.domain.member.repository.MemberRepository;
 import com.api.trip.domain.member.service.MemberService;
 import jakarta.mail.MessagingException;
@@ -46,8 +47,7 @@ public class EmailService {
     @Async
     public void send(String email) {
 
-        // TODO: 비동기 메서드 예외 핸들러 추가
-        memberRepository.findByEmail(email).ifPresent(it -> {
+        memberRepository.findByEmailAndSocialCode(email, SocialCode.NORMAL).ifPresent(it -> {
             throw new DuplicateException(ErrorCode.ALREADY_JOINED);
         });
 

--- a/src/main/java/com/api/trip/domain/member/model/Member.java
+++ b/src/main/java/com/api/trip/domain/member/model/Member.java
@@ -1,7 +1,6 @@
 package com.api.trip.domain.member.model;
 
 import com.api.trip.common.auditing.entity.BaseTimeEntity;
-import com.api.trip.domain.member.controller.dto.JoinRequest;
 import com.api.trip.domain.member.controller.dto.UpdateProfileRequest;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -76,6 +75,13 @@ public class Member extends BaseTimeEntity {
                 .socialCode(socialCode)
                 .socialAccessToken(socialAccessToken)
                 .build();
+    }
+
+    public void updateSocialMember(String email, String name, String picture, String socialAccessToken) {
+        this.email = email;
+        this.nickname = name;
+        this.profileImg = picture;
+        this.socialAccessToken = socialAccessToken;
     }
 
     public void changePassword(String password) {

--- a/src/main/java/com/api/trip/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/api/trip/domain/member/repository/MemberRepository.java
@@ -1,10 +1,14 @@
 package com.api.trip.domain.member.repository;
 
 import com.api.trip.domain.member.model.Member;
+import com.api.trip.domain.member.model.SocialCode;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
+    
+    Optional<Member> findByEmailAndSocialCode(String email, SocialCode socialCode);
+
 }


### PR DESCRIPTION
- 소셜 회원의 이메일과 닉네임에 붙였던 `provider_` 제거
- 플랫폼이 달라도 같은 이메일을 사용하는 경우가 있기 때문에, 소셜 코드를 통해 이미 가입된 이메일인 경우에도 플랫폼이 다르면 회원 가입이 가능하도록 수정
- 소셜 계정의 정보가 변경되면 db에도 반영되도록 수정


This closed #188 
